### PR TITLE
add some feature to WaitGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ if err := wg.Wait(); err != nil {
 } 
 ```
 
+**or you can use Do method and let WaitGroup handle Add and Done internally.**
+
+```go
+wg := errors.NewWaitGroup() 
+
+wg.Do(func() error {
+    return callingHttpClient()
+})
+
+wg.Do(func() error {
+    return callingHttpClient()
+})
+
+
+if err := wg.Wait(); err != nil {
+    // oh, something bad happened in one of routines above.
+} 
+```
+
+
 for mode details, check the [documentation](https://godoc.org/github.com/mrsoftware/errors)
 
 ----

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ if err := errorList.Err(); err != nil {
 ## Combining sync.WaitGroup and errors.MultiError
 The `errors.WaitGroup` type simplifies error handling in concurrent operations by merging `sync.WaitGroup` with `MultiError`. This reduces boilerplate code for cleaner and more concise error handling:
 ```go
-wg := &errors.WaitGroup{}
+wg := errors.NewWaitGroup() // you can pass some options, e.g: your custom sync.WaitGroup using WaitGroupWithSyncWaitGroup.
 
 wg.Add(1)
 go func(){

--- a/README.md
+++ b/README.md
@@ -140,6 +140,29 @@ if err := wg.Wait(); err != nil {
 } 
 ```
 
+## limiting the concurrent task counts using limit Options in errors.WaitGroup
+```go
+wg := errors.NewWaitGroup(errors.WaitGroupWithTaskLimit(2)) 
+
+wg.Do(func() error {
+    return callingHttpClient()
+})
+
+wg.Do(func() error {
+    return callingHttpClient()
+})
+
+// we set limit concurrent task to 2, so this task will block until one of above are done.
+wg.Do(func() error {
+	return callingHttpClient()
+})
+
+if err := wg.Wait(); err != nil {
+    // oh, something bad happened in one of routines above.
+} 
+```
+
+
 
 for mode details, check the [documentation](https://godoc.org/github.com/mrsoftware/errors)
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,28 @@ if err := wg.Wait(); err != nil {
 } 
 ```
 
+## Use Custom runner instead of GoRoutine in errors.WaitGroup
+```go
+import (
+    "github.com/mrsoftware/errors"
+    "github.com/panjf2000/ants/v2"
+)
+
+// in this example we are using ants goroutine pool.
+wg := errors.NewWaitGroup(errors.WaitGroupWithTaskRunner(ants.Submit)) 
+
+wg.Do(func() error {
+    return callingHttpClient()
+})
+
+wg.Do(func() error {
+    return callingHttpClient()
+})
+ 
+if err := wg.Wait(); err != nil {
+    // oh, something bad happened in one of routines above.
+} 
+```
 
 
 for mode details, check the [documentation](https://godoc.org/github.com/mrsoftware/errors)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,52 @@ if err := wg.Wait(); err != nil {
     // oh, something bad happened in one of routines above.
 } 
 ```
+## Stop all tasks on first error
+```go
+import (
+    "github.com/mrsoftware/errors"
+)
 
+// in this example we are using ants goroutine pool.
+wg := errors.NewWaitGroup(errors.WaitGroupWithStopOnError()) 
+
+ctx := wg.Context()
+
+wg.Do(func() error {
+    return callingHttpClient(ctx)
+})
+
+wg.Do(func() error {
+    return callingHttpClient(ctx)
+})
+ 
+// if one of above task failed, context will cancel and other task will stop (the task must ba aware of context cancellation like http pkg do)
+
+if err := wg.Wait(); err != nil {
+    // oh, something bad happened in one of routines above.
+} 
+```
+**or you can use NewWaitGroupWithContext method:**
+```go
+import (
+    "github.com/mrsoftware/errors"
+)
+
+// in this example we are using ants goroutine pool.
+ctx, wg := errors.NewWaitGroupWithContext(context.Background(), errors.WaitGroupWithStopOnError()) 
+
+wg.Do(func() error {
+    return callingHttpClient(ctx)
+})
+
+wg.Do(func() error {
+    return callingHttpClient(ctx)
+})
+ 
+if err := wg.Wait(); err != nil {
+    // oh, something bad happened in one of routines above.
+} 
+```
 
 for mode details, check the [documentation](https://godoc.org/github.com/mrsoftware/errors)
 

--- a/multi.go
+++ b/multi.go
@@ -112,3 +112,17 @@ func (m *MultiError) Is(err error) bool {
 
 	return false
 }
+
+// As implements errors.As by attempting to map to the current value.
+func (m *MultiError) As(target interface{}) bool {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	for i := range m.errors {
+		if errors.As(m.errors[i], target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/multi_test.go
+++ b/multi_test.go
@@ -115,3 +115,28 @@ func TestMultiError_Is(t *testing.T) {
 		assert.False(t, stdErr.Is(err, error3))
 	})
 }
+
+func TestMultiError_As(t *testing.T) {
+	t.Run("requested err found in list, expect to get true", func(t *testing.T) {
+		error1 := stdErr.New("error 1")
+		error2 := New("my error")
+
+		err := NewMultiError(error1, error2)
+
+		myErr := &Error{}
+
+		assert.True(t, stdErr.As(err, &myErr))
+		assert.Equal(t, error2, myErr)
+	})
+
+	t.Run("requested err is not in list, expect to get false", func(t *testing.T) {
+		error1 := stdErr.New("error 1")
+		error2 := stdErr.New("error 2")
+
+		err := NewMultiError(error1, error2)
+
+		myErr := &Error{}
+
+		assert.False(t, stdErr.As(err, &myErr))
+	})
+}

--- a/waitGroup.go
+++ b/waitGroup.go
@@ -49,6 +49,13 @@ func (g *WaitGroup) Done(err error) {
 	g.errors.Add(err)
 }
 
+// Do calls the given function in a new goroutine.
+func (g *WaitGroup) Do(f func() error) {
+	g.Add(1)
+
+	go func() { g.Done(f()) }()
+}
+
 // noCopy may be embedded into structs which must not be copied
 // after the first use.
 //

--- a/waitGroup_test.go
+++ b/waitGroup_test.go
@@ -77,6 +77,22 @@ func TestGroup(t *testing.T) {
 		err := wg.Wait()
 		assert.Nil(t, err)
 	})
+
+	t.Run("expect to Do method act as combination of Add and Done method together", func(t *testing.T) {
+		error1 := errors.New("error 1")
+
+		wg := NewWaitGroup()
+
+		wg.Do(func() error { return error1 })
+
+		wg.Do(func() error { return nil })
+
+		err := wg.Wait()
+
+		expected := NewMultiError(error1)
+
+		assert.ElementsMatch(t, expected.errors, err.(*MultiError).errors)
+	})
 }
 
 // all below test cases are copied from sync/waitgroup_test.go and transformed to group.

--- a/waitGroup_test.go
+++ b/waitGroup_test.go
@@ -111,6 +111,26 @@ func TestGroup(t *testing.T) {
 		err := wg.Wait()
 		assert.Nil(t, err)
 	})
+
+	t.Run("using custom task runner, expect to use my task runner and not GoRoutine", func(t *testing.T) {
+		var isUsedCustomRunner bool
+		// custom task Runner for test
+		runner := func(task func()) {
+			task()
+
+			isUsedCustomRunner = true
+		}
+
+		wg := NewWaitGroup(WaitGroupWithTaskRunner(runner))
+
+		wg.Do(func() error {
+			return nil
+		})
+
+		err := wg.Wait()
+		assert.Nil(t, err)
+		assert.True(t, isUsedCustomRunner)
+	})
 }
 
 // all below test cases are copied from sync/waitgroup_test.go and transformed to group.

--- a/waitGroup_test.go
+++ b/waitGroup_test.go
@@ -52,6 +52,31 @@ func TestGroup(t *testing.T) {
 		err := wg.Wait()
 		assert.ElementsMatch(t, expected.errors, err.(*MultiError).errors)
 	})
+
+	t.Run("expect to use passed waitGroup in options", func(t *testing.T) {
+		goWG := &sync.WaitGroup{}
+
+		wg := NewWaitGroup(WaitGroupWithSyncWaitGroup(goWG))
+
+		goWG.Add(1)
+
+		go func() {
+			goWG.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			wg.Done(nil)
+		}()
+
+		wg.Add(1)
+		go func() {
+			wg.Done(nil)
+		}()
+
+		err := wg.Wait()
+		assert.Nil(t, err)
+	})
 }
 
 // all below test cases are copied from sync/waitgroup_test.go and transformed to group.
@@ -83,8 +108,8 @@ func testWaitGroup(t *testing.T, wg1 *WaitGroup, wg2 *WaitGroup) {
 }
 
 func TestWaitGroup(t *testing.T) {
-	wg1 := &WaitGroup{}
-	wg2 := &WaitGroup{}
+	wg1 := NewWaitGroup()
+	wg2 := NewWaitGroup()
 
 	// Run the same test a few times to ensure barrier is in a proper state.
 	for i := 0; i != 8; i++ {
@@ -99,7 +124,7 @@ func TestWaitGroupMisuse(t *testing.T) {
 			t.Fatalf("Unexpected panic: %#v", err)
 		}
 	}()
-	wg := &WaitGroup{}
+	wg := NewWaitGroup()
 	wg.Add(1)
 	wg.Done(nil)
 	wg.Done(nil)
@@ -109,7 +134,7 @@ func TestWaitGroupMisuse(t *testing.T) {
 func TestWaitGroupRace(t *testing.T) {
 	// Run this test for about 1ms.
 	for i := 0; i < 1000; i++ {
-		wg := &WaitGroup{}
+		wg := NewWaitGroup()
 		n := new(int32)
 		// spawn goroutine 1
 		wg.Add(1)


### PR DESCRIPTION
- add options capability to waitGroup and support for parent sync.WaitGroup
- add the Do method for better DX
- create WaitGroupWithTaskLimit option to control concurrent task in Do method
- create WaitGroupWithTaskRunner option to control task runner
- create WaitGroupWithStopOnError option to cancel other tasks and NewWaitGroupWithContext function to create WaitGroup with custom context